### PR TITLE
setRootTemplate when CarPlay starts

### DIFF
--- a/ios/Classes/FlutterCarplayPluginSceneDelegate.swift
+++ b/ios/Classes/FlutterCarplayPluginSceneDelegate.swift
@@ -62,12 +62,9 @@ class FlutterCarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelega
     SwiftFlutterCarplayPlugin.onCarplayConnectionChange(status: FCPConnectionTypes.connected)
     let rootTemplate = SwiftFlutterCarplayPlugin.rootTemplate
 
-    guard rootTemplate != nil else {
-      FlutterCarPlaySceneDelegate.interfaceController = nil
-      return
+    if rootTemplate != nil {
+      FlutterCarPlaySceneDelegate.interfaceController?.setRootTemplate(rootTemplate!, animated: SwiftFlutterCarplayPlugin.animated, completion: nil)
     }
-    
-    FlutterCarPlaySceneDelegate.interfaceController?.setRootTemplate(rootTemplate!, animated: SwiftFlutterCarplayPlugin.animated)
   }
   
   func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene,


### PR DESCRIPTION
This commit checks if the SwiftFlutterCarplayPlugin.rootTemplate is nil If it is nil, that means the Flutter app hasn't start up. If we end up in this situation, we want to manually call setRootTemplate to boot up the Flutter app.

We need to do this since this package lives in the Flutter world. If Flutter doesn't boot up then the CarPlay app will not work by showing a blank screen on the device.